### PR TITLE
Add ROCm's HIP support to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.6)
 set(CMAKE_CXX_STANDARD 17)
-project(swaptube LANGUAGES CXX CUDA)
+project(swaptube LANGUAGES CXX)
 
 set(ENV{GLIBCXX_FORCE_NEW} 1)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
@@ -12,7 +12,36 @@ find_package(PkgConfig REQUIRED)
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 find_package(PNG REQUIRED)
 find_package(glm REQUIRED)
-find_package(CUDA REQUIRED)
+
+# Configure CUDA or ROCm.
+find_package(CUDA)
+set(GPU_LIBRARIES)
+
+if(CUDA_FOUND)
+  message (STATUS "CUDA libraries found. Configuring for CUDA. Libraries -> " ${CUDA_LIBRARIES})
+  set(GPU_LANGUAGE CUDA)
+  enable_language(CUDA)
+  set(GPU_COMPILER ${CMAKE_CUDA_COMPILER})
+  set(GPU_ARCHITECTURE ${CMAKE_CUDA_ARCHITECTURES})
+  list(APPEND GPU_LIBRARIES ${CUDA_LIBRARIES})
+
+# ROCm's HIP (Heterogeneous-Compute Interface for Portability) API
+# - https://rocm.docs.amd.com/en/latest/conceptual/cmake-packages.html
+else()
+  list(APPEND CMAKE_PREFIX_PATH /opt/rocm/hip /opt/rocm)
+  find_package(HIP REQUIRED)
+
+  if(HIP_FOUND)
+    message(STATUS "HIP found. Configuring for HIP. Libraries -> " ${HIP_LIBRARIES})
+    set(GPU_LANGUAGE HIP)
+    enable_language(HIP)
+
+    set(GPU_COMPILER ${HIP_COMPILER})
+    list(APPEND GPU_LIBRARIES hip::host)
+  else()
+    message(FATAL_ERROR "Neither CUDA nor ROCm's HIP was found on this system.")
+  endif()
+endif()
 
 include_directories(${PROJECT_NAME} ${FFMPEG_INCLUDE_DIRS} ${RSVG_INCLUDE_DIRS})
 include_directories("/usr/include/glib-2.0")
@@ -22,13 +51,23 @@ include_directories("/usr/include/cairo")
 include_directories(${EIGEN3_INCLUDE_DIR})
 include_directories(${PNG_INCLUDE_DIR})
 include_directories(${GLM_INCLUDE_DIRS})
-include_directories(${CUDA_INCLUDE_DIRS})
 
-file(GLOB_RECURSE CUDA_SOURCES "src/CUDA/*.cu")
+if(GPU_LANGUAGE STREQUAL "CUDA")
+  include_directories(${CUDA_INCLUDE_DIRS})
+  file(GLOB_RECURSE CUDA_SOURCES "src/CUDA/*.cu")
+  add_executable(${PROJECT_NAME} "src/projects/.active_project.cpp" ${CUDA_SOURCES})
+else()
+  include_directories(${HIP_INCLUDE_DIRS})
+  file(GLOB_RECURSE HIP_SOURCES "src/ROCm/*.hip")
 
-add_executable(${PROJECT_NAME} "src/projects/.active_project.cpp" ${CUDA_SOURCES})
+  # Set the main entrypoint's source file + update properties for which to compile non '.hip'
+  # files as HIP ones.
+  set(MAIN_ROCM_SOURCE_FILE "src/projects/rocm_hip_main.cc")
+  set_source_files_properties(${MAIN_ROCM_SOURCE_FILE} PROPERTIES LANGUAGE HIP)
+  add_executable(${PROJECT_NAME} ${MAIN_ROCM_SOURCE_FILE} ${HIP_SOURCES})
+endif()
 
-target_link_libraries(${PROJECT_NAME} ${FFMPEG_LIBRARIES} ${SWSCALE_LIBRARIES} ${RSVG_LIBRARIES} cairo gobject-2.0 ${PNG_LIBRARIES} ${CUDA_LIBRARIES})
 
+target_link_libraries(${PROJECT_NAME} ${FFMPEG_LIBRARIES} ${SWSCALE_LIBRARIES} ${RSVG_LIBRARIES} cairo gobject-2.0 ${PNG_LIBRARIES} ${GPU_LIBRARIES})
 target_compile_options(${PROJECT_NAME} PRIVATE -Wreorder)
 

--- a/src/ROCm/test_rocm.hip
+++ b/src/ROCm/test_rocm.hip
@@ -1,0 +1,13 @@
+#include "hip/hip_runtime.h"
+
+__global__
+void vectoradd_float(float* __restrict__ a, const float* __restrict__ b, const float* __restrict__ c, int width, int height) {
+    int x = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+    int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
+
+    int i = y * width + x;
+    if ( i < (width * height)) {
+      a[i] = b[i] + c[i];
+    }
+}
+

--- a/src/projects/rocm_hip_main.cc
+++ b/src/projects/rocm_hip_main.cc
@@ -1,0 +1,102 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include<iostream>
+
+#include "hip/hip_runtime.h"
+
+using namespace std;
+
+#ifdef NDEBUG
+#define HIP_ASSERT(x) x
+#else
+#define HIP_ASSERT(x) (assert((x)==hipSuccess))
+#endif
+
+
+#define WIDTH     1024
+#define HEIGHT    1024
+
+#define NUM       (WIDTH*HEIGHT)
+
+#define THREADS_PER_BLOCK_X  16
+#define THREADS_PER_BLOCK_Y  16
+#define THREADS_PER_BLOCK_Z  1
+
+
+// Forward declare from .hip source.
+__global__
+void vectoradd_float(float* __restrict__ a, const float* __restrict__ b, const float* __restrict__ c, int width, int height);
+
+int main() {
+
+  float* hostA;
+  float* hostB;
+  float* hostC;
+
+  float* deviceA;
+  float* deviceB;
+  float* deviceC;
+
+  hipDeviceProp_t devProp;
+  hipGetDeviceProperties(&devProp, 0);
+  cout << " System minor " << devProp.minor << endl;
+  cout << " System major " << devProp.major << endl;
+  cout << " agent prop name " << devProp.name << endl;
+  cout << "hip Device prop succeeded " << endl ;
+
+  int i;
+  int errors;
+
+  hostA = (float*)malloc(NUM * sizeof(float));
+  hostB = (float*)malloc(NUM * sizeof(float));
+  hostC = (float*)malloc(NUM * sizeof(float));
+
+  // initialize the input data
+  for (i = 0; i < NUM; i++) {
+    hostB[i] = (float)i;
+    hostC[i] = (float)i*100.0f;
+  }
+
+  HIP_ASSERT(hipMalloc((void**)&deviceA, NUM * sizeof(float)));
+  HIP_ASSERT(hipMalloc((void**)&deviceB, NUM * sizeof(float)));
+  HIP_ASSERT(hipMalloc((void**)&deviceC, NUM * sizeof(float)));
+
+  HIP_ASSERT(hipMemcpy(deviceB, hostB, NUM*sizeof(float), hipMemcpyHostToDevice));
+  HIP_ASSERT(hipMemcpy(deviceC, hostC, NUM*sizeof(float), hipMemcpyHostToDevice));
+
+
+  hipLaunchKernelGGL(vectoradd_float,
+                  dim3(WIDTH/THREADS_PER_BLOCK_X, HEIGHT/THREADS_PER_BLOCK_Y),
+                  dim3(THREADS_PER_BLOCK_X, THREADS_PER_BLOCK_Y),
+                  0, 0,
+                  deviceA ,deviceB ,deviceC ,WIDTH ,HEIGHT);
+
+
+  HIP_ASSERT(hipMemcpy(hostA, deviceA, NUM*sizeof(float), hipMemcpyDeviceToHost));
+
+  // verify the results
+  errors = 0;
+  for (i = 0; i < NUM; i++) {
+    if (hostA[i] != (hostB[i] + hostC[i])) {
+      errors++;
+    }
+  }
+  if (errors!=0) {
+    printf("FAILED: %d errors\n",errors);
+  } else {
+      printf ("PASSED!\n");
+  }
+
+  HIP_ASSERT(hipFree(deviceA));
+  HIP_ASSERT(hipFree(deviceB));
+  HIP_ASSERT(hipFree(deviceC));
+
+  free(hostA);
+  free(hostB);
+  free(hostC);
+
+  //hipResetDefaultAccelerator();
+
+  return errors;
+}


### PR DESCRIPTION
## Overview
This simply adds fallback support from CUDA to ROCm, keeping the build priority to CUDA.

## Verification
Generating CMake build directory. 
```sh
➜ swaptube git:(dev/add-rocm-support) ✗ mkdir build
➜ swaptube git:(dev/add-rocm-support) ✗ cd build
➜ build git:(dev/add-rocm-support) ✗ cmake ..
-- The CXX compiler identification is GNU 14.1.1
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.1.1")
-- Checking for module 'libavcodec'
--   Found libavcodec, version 61.3.100
-- Checking for module 'libavformat'
--   Found libavformat, version 61.1.100
-- Checking for module 'libavdevice'
--   Found libavdevice, version 61.1.100
-- Checking for module 'libavutil'
--   Found libavutil, version 59.8.100
-- Checking for module 'libavfilter'
--   Found libavfilter, version 10.1.100
-- Checking for module 'libswscale'
--   Found libswscale, version 8.1.100
-- Checking for module 'libpostproc'
--   Found libpostproc, version 58.1.100
-- Checking for module 'libswresample'
--   Found libswresample, version 5.1.100
-- Found FFmpeg: /usr/lib/libavcodec.so;/usr/lib/libavformat.so;/usr/lib/libavutil.so
-- Checking for module 'cairo'
--   Found cairo, version 1.18.0
-- Found Cairo: /usr/include/cairo
-- Found RSVG: /usr/lib/librsvg-2.so
-- Found ZLIB: /usr/lib/libz.so (found version "1.3.1")
-- Found PNG: /usr/lib/libpng.so (found version "1.6.43")
CMake Warning (dev) at CMakeLists.txt:17 (find_package):
  Policy CMP0146 is not set: The FindCUDA module is removed.  Run "cmake
  --help-policy CMP0146" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.

CUDA_TOOLKIT_ROOT_DIR not found or specified
-- Could NOT find CUDA (missing: CUDA_TOOLKIT_ROOT_DIR CUDA_NVCC_EXECUTABLE CUDA_INCLUDE_DIRS CUDA_CUDART_LIBRARY)
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- HIP found. Configuring for HIP. Libraries -> hip::hosthip::device
-- The HIP compiler identification is Clang 17.0.0
-- Detecting HIP compiler ABI info
-- Detecting HIP compiler ABI info - done
-- Check for working HIP compiler: /opt/rocm/llvm/bin/clang++ - skipped
-- Detecting HIP compile features
-- Detecting HIP compile features - done
-- Configuring done (2.9s)
-- Generating done (0.0s)
-- Build files have been written to: /tmp/tmp.WmiNKNAdwp/swaptube/build
```

We can see CUDA failing to be found then falling back to finding ROCm's HIP libraries.
```
CUDA_TOOLKIT_ROOT_DIR not found or specified
-- Could NOT find CUDA (missing: CUDA_TOOLKIT_ROOT_DIR CUDA_NVCC_EXECUTABLE CUDA_INCLUDE_DIRS CUDA_CUDART_LIBRARY)
...
-- HIP found. Configuring for HIP. Libraries -> hip::hosthip::device
-- The HIP compiler identification is Clang 17.0.0
```

Then compiling the main source for ROCm:
```sh
➜ build git:(dev/add-rocm-support) ✗ make
[ 33%] Building HIP object CMakeFiles/swaptube.dir/src/projects/rocm_hip_main.cc.o
/tmp/tmp.WmiNKNAdwp/swaptube/src/projects/rocm_hip_main.cc:42:3: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  hipGetDeviceProperties(&devProp, 0);
  ^~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~
/opt/rocm/include/hip/hip_runtime_api.h:91:32: note: expanded from macro 'hipGetDeviceProperties'
#define hipGetDeviceProperties hipGetDevicePropertiesR0600
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated when compiling for gfx1100.
/tmp/tmp.WmiNKNAdwp/swaptube/src/projects/rocm_hip_main.cc:42:3: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  hipGetDeviceProperties(&devProp, 0);
  ^~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~~~~~
/opt/rocm/include/hip/hip_runtime_api.h:91:32: note: expanded from macro 'hipGetDeviceProperties'
#define hipGetDeviceProperties hipGetDevicePropertiesR0600
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated when compiling for host.
[ 66%] Building HIP object CMakeFiles/swaptube.dir/src/ROCm/test_rocm.hip.o
[100%] Linking HIP executable swaptube
[100%] Built target swaptube
```

and finally can execute and we get passing tests (obtained from https://github.com/ROCm/HIP-Examples/blob/master/vectorAdd/vectoradd_hip.cpp):
```sh
➜ build git:(dev/add-rocm-support) ✗ ./swaptube
 System minor 0
 System major 11
 agent prop name AMD Radeon RX 7900 XTX
hip Device prop succeeded
PASSED!
```