### PR TITLE
Replace av_err2str with thread-safe ff_errstr wrapper

### DIFF
--- a/src/io/AudioWriter.cpp
+++ b/src/io/AudioWriter.cpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "../misc/ffmpeg_error.hpp"
 #include <sys/stat.h>
 #include <vector>
 #include <iostream>
@@ -122,7 +123,7 @@ public:
 
             int ret = avcodec_open2(codecCtx, audioOutputCodec, nullptr);
             if (ret < 0) {
-                cout << "avcodec_open2 error: " << av_err2str(ret) << endl;
+                cout << "avcodec_open2 error: " << ff_errstr(ret) << endl;
                 avcodec_free_context(&codecCtx);
                 throw runtime_error(string("Error: Could not open encoder ") + codec_name + ".");
             }
@@ -392,7 +393,7 @@ public:
                     av_frame_free(&frameSFX);
                     av_frame_free(&frameVoice);
                     av_frame_free(&frameBlips);
-                    throw runtime_error("Error allocating audio frame buffer: " + string(av_err2str(ret)));
+                    throw runtime_error("Error allocating audio frame buffer: " + string(ff_errstr(ret)));
                 }
             };
 

--- a/src/io/VideoWriter.cpp
+++ b/src/io/VideoWriter.cpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "../misc/ffmpeg_error.hpp"
 #include <iostream>
 #include <string>
 #include <regex>
@@ -6,6 +7,7 @@
 #include "DebugPlot.h"
 #include "../misc/pixels.h"
 #include "IoHelpers.cpp"
+
 extern "C"
 {
     #include <libavcodec/avcodec.h>
@@ -146,7 +148,7 @@ public:
 
         ret = avformat_write_header(fc, &opt);
         if (ret < 0) {
-            cout << "Failed to write header: " << av_err2str(ret) << endl;
+            cout << "Failed to write header: " << ff_errstr(ret) << endl;
             throw runtime_error("Failed to write header!");
         }
 

--- a/src/misc/ffmpeg_error.hpp
+++ b/src/misc/ffmpeg_error.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+extern "C" {
+#include <libavutil/error.h>  // AV_ERROR_MAX_STRING_SIZE, av_strerror
+}
+
+#include <string>
+
+static inline std::string ff_errstr(int errnum) {
+    char buf[AV_ERROR_MAX_STRING_SIZE];
+    if (av_strerror(errnum, buf, sizeof(buf)) < 0) {
+        return "Unknown FFmpeg error " + std::to_string(errnum);
+    }
+    return std::string(buf);
+}
+


### PR DESCRIPTION
- Update AudioWriter.cpp and VideoWriter.cpp to use ff_errstr
- Fixes compilation issues with av_err2str macro in C++