### PR TITLE
Nix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,19 @@ The following external dependencies are required for specific functionalities wi
 ## Docker Setup
 For easy deployment with all dependencies included, see the [docker/README.md](docker/README.md) for containerized setup instructions. This is optional and community-made for Docker users. I (2swap) personally don't use or maintain it.
 
+## NixOS Setup
+If you are using NixOS or the Nix package manager, you can use the provided flake.
+
+### CUDA
+```bash
+nix develop
+```
+
+### HIP
+```bash
+nix develop .#hip
+```
+
 # How to Run
 When you have created a project file `Projects/yourprojectname.cpp`, you can compile and run the whole project by executing:
 

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,22 @@
         "type": "github"
       }
     },
+    "microtex-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1722910131,
+        "narHash": "sha256-U6zqh+VqoLtlE0IwgfwjY9zt8e5/2R3cqf5fWXwoIi0=",
+        "owner": "NanoMichael",
+        "repo": "MicroTeX",
+        "rev": "0e3707f6dafebb121d98b53c64364d16fefe481d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NanoMichael",
+        "repo": "MicroTeX",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1779560665,
@@ -37,6 +53,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "microtex-src": "microtex-src",
         "nixpkgs": "nixpkgs"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1779560665,
+        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,6 @@
                     default = pkgs.mkShell {
                         buildInputs = basePackages ++ [
                             pkgs.cudatoolkit
-                            pkgs.linuxPackages.nvidia_x11
                         ];
 
                         shellHook = ''

--- a/flake.nix
+++ b/flake.nix
@@ -34,10 +34,6 @@
                         pkgs.gtksourceviewmm
                     ];
 
-                    cmakeFlags = [
-                        "-DBUILD_SHARED_LIBS=ON"
-                    ];
-
                     installPhase = ''
                         mkdir -p $out/build
                         cp LaTeX $out/build/

--- a/flake.nix
+++ b/flake.nix
@@ -7,28 +7,49 @@
     };
 
     outputs = { self, nixpkgs, flake-utils }:
-        flake-utils.lib.eachDefaultSystem (system:
+        flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
             let
-                pkgs = import nixpkgs { inherit system; };
-            in {
-                devShells.default = pkgs.mkShell {
-                    buildInputs = [
-                        pkgs.bashInteractive
-                        pkgs.cmake
-                        pkgs.ninja
-                        pkgs.ffmpeg
-                        pkgs.librsvg
-                        pkgs.glib
-                        pkgs.cairo
-                        pkgs.libpng
-                        pkgs.gnuplot
-                    ];
+                pkgs = import nixpkgs {
+                    inherit system;
+                    config = { allowUnfree = true; };
+                };
 
-                    shellHook = ''
-                        echo "you need microtex to run swaptube, so run:"
-                        echo " git clone https://github.com/NanoMichael/MicroTeX.git ../MicroTeX-master"
-                        echo "and follow the build instructions at https://github.com/NanoMichael/MicroTeX/"
-                    '';
+                basePackages = [
+                    pkgs.bashInteractive
+                    pkgs.cmake
+                    pkgs.ninja
+                    pkgs.ffmpeg
+                    pkgs.librsvg
+                    pkgs.glib
+                    pkgs.cairo
+                    pkgs.libpng
+                    pkgs.gnuplot
+                ];
+
+                welcomeHook = gpuType: ''
+                    echo "you need microtex to run swaptube, so run:"
+                    echo " git clone https://github.com/NanoMichael/MicroTeX.git ../MicroTeX-master"
+                    echo "and follow the build instructions at https://github.com/NanoMichael/MicroTeX/"
+                    echo "[type ${gpuType}]"
+                '';
+            in {
+                devShells = {
+                    default = pkgs.mkShell {
+                        buildInputs = basePackages ++ [
+                            pkgs.cudatoolkit
+                            pkgs.linuxPackages.nvidia_x11
+                        ];
+
+                        shellHook = welcomeHook "CUDA";
+                    };
+
+                    hip = pkgs.mkShell {
+                        buildInputs = basePackages ++ [
+                            pkgs.rocmPackages.clr
+                        ];
+
+                        shellHook = welcomeHook "HIP/ROCm";
+                    };
                 };
             });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
                     '';
 
                     noAuditTmpdir = true;
-                    dontPatchELF = true;
                 };
 
                 basePackages = [

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
                         pkgs.bashInteractive
                         pkgs.cmake
                         pkgs.ninja
-                        pkgs.ffmpeg_5
+                        pkgs.ffmpeg
                         pkgs.librsvg
                         pkgs.glib
                         pkgs.cairo

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+    description = "swaptube dev env";
+
+    inputs = {
+        nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = { self, nixpkgs, flake-utils }:
+        flake-utils.lib.eachDefaultSystem (system:
+            let
+                pkgs = import nixpkgs { inherit system; };
+            in {
+                devShells.default = pkgs.mkShell {
+                    buildInputs = [
+                        pkgs.bashInteractive
+                        pkgs.cmake
+                        pkgs.ninja
+                        pkgs.ffmpeg_5
+                        pkgs.librsvg
+                        pkgs.glib
+                        pkgs.cairo
+                        pkgs.libpng
+                        pkgs.gnuplot
+                    ];
+
+                    shellHook = ''
+                        echo "you need microtex to run swaptube, so run:"
+                        echo " git clone https://github.com/NanoMichael/MicroTeX.git ../MicroTeX-master"
+                        echo "and follow the build instructions at https://github.com/NanoMichael/MicroTeX/"
+                    '';
+                };
+            });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -24,13 +24,29 @@
                     pkgs.cairo
                     pkgs.libpng
                     pkgs.gnuplot
+                    pkgs.pkg-config 
+                    pkgs.llvmPackages.lld
+                    pkgs.glib.dev
+                    pkgs.xz
+                    pkgs.gdk-pixbuf
                 ];
+
+                rocmMerged = pkgs.symlinkJoin {
+                    name = "rocm-merged";
+                    paths = [
+                        pkgs.rocmPackages.clr
+                        pkgs.rocmPackages.hipify
+                        pkgs.rocmPackages.rocprim
+                        pkgs.rocmPackages.rocthrust
+                    ];
+                };
 
                 welcomeHook = gpuType: ''
                     echo "you need microtex to run swaptube, so run:"
                     echo " git clone https://github.com/NanoMichael/MicroTeX.git ../MicroTeX-master"
                     echo "and follow the build instructions at https://github.com/NanoMichael/MicroTeX/"
                     echo "[type ${gpuType}]"
+                    export NIX_CFLAGS_COMPILE="-I${pkgs.gdk-pixbuf.dev}/include/gdk-pixbuf-2.0 -I${pkgs.cairo.dev}/include/cairo $NIX_CFLAGS_COMPILE";
                 '';
             in {
                 devShells = {
@@ -40,15 +56,23 @@
                             pkgs.linuxPackages.nvidia_x11
                         ];
 
-                        shellHook = welcomeHook "CUDA";
+                        shellHook = ''
+                            ${welcomeHook "CUDA"}
+                            export CUDA_PATH="${pkgs.cudatoolkit}"
+                        '';
                     };
 
                     hip = pkgs.mkShell {
                         buildInputs = basePackages ++ [
-                            pkgs.rocmPackages.clr
+                            rocmMerged
                         ];
 
-                        shellHook = welcomeHook "HIP/ROCm";
+                        shellHook = ''
+                            ${welcomeHook "HIP/ROCm"}
+                            export ROCM_PATH="${rocmMerged}"
+                            export HIP_PATH="${rocmMerged}"
+                            export NIX_CFLAGS_COMPILE="-I${rocmMerged}/include $NIX_CFLAGS_COMPILE";
+                        '';
                     };
                 };
             });

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,51 @@
     inputs = {
         nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
         flake-utils.url = "github:numtide/flake-utils";
+        microtex-src = {
+            url = "github:NanoMichael/MicroTeX";
+            flake = false;
+        };
     };
 
-    outputs = { self, nixpkgs, flake-utils }:
+    outputs = { self, nixpkgs, flake-utils, microtex-src }:
         flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
             let
                 pkgs = import nixpkgs {
                     inherit system;
                     config = { allowUnfree = true; };
+                };
+
+                microtex = pkgs.stdenv.mkDerivation {
+                    name = "microtex";
+                    src = microtex-src;
+                    nativeBuildInputs = [
+                        pkgs.cmake
+                        pkgs.pkg-config
+                    ];
+
+                    buildInputs = [
+                        pkgs.tinyxml-2
+                        pkgs.fontconfig
+                        pkgs.gtkmm3
+                        pkgs.gtksourceview
+                        pkgs.gtksourceviewmm
+                    ];
+
+                    cmakeFlags = [
+                        "-DBUILD_SHARED_LIBS=ON"
+                    ];
+
+                    installPhase = ''
+                        mkdir -p $out/build
+                        cp LaTeX $out/build/
+                        cp libLaTeX.so $out/build/ 2>/dev/null || true
+                        cp -r $src/src $out/
+                        cp -r $src/res $out/
+                        cp $src/CMakeLists.txt $out/
+                    '';
+
+                    noAuditTmpdir = true;
+                    dontPatchELF = true;
                 };
 
                 basePackages = [
@@ -29,6 +66,7 @@
                     pkgs.glib.dev
                     pkgs.xz
                     pkgs.gdk-pixbuf
+                    microtex
                 ];
 
                 rocmMerged = pkgs.symlinkJoin {
@@ -42,11 +80,13 @@
                 };
 
                 welcomeHook = gpuType: ''
-                    echo "you need microtex to run swaptube, so run:"
-                    echo " git clone https://github.com/NanoMichael/MicroTeX.git ../MicroTeX-master"
-                    echo "and follow the build instructions at https://github.com/NanoMichael/MicroTeX/"
                     echo "[type ${gpuType}]"
                     export NIX_CFLAGS_COMPILE="-I${pkgs.gdk-pixbuf.dev}/include/gdk-pixbuf-2.0 -I${pkgs.cairo.dev}/include/cairo $NIX_CFLAGS_COMPILE";
+                    if [ ! -L "../MicroTeX-master" ] && [ ! -d "../MicroTeX-master" ]; then
+                        ln -s ${microtex} ../MicroTeX-master
+                    fi
+
+                    trap 'echo "cleaning up symlink"; rm -f ../MicroTeX-master' EXIT # shouldn't delete a cloned repo if it exists for some reason
                 '';
             in {
                 devShells = {

--- a/go.sh
+++ b/go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 clear
 check_command_available() {

--- a/play.sh
+++ b/play.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 check_media_player_exists() {
     # Try each player in order and pick the first available one

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # List of demo projects
 mapfile -t DEMOS < <(find src/Projects/Demos -type f -name '*.cpp' -printf '%f\n' | sed 's/\.cpp$//')

--- a/upload.sh
+++ b/upload.sh
@@ -1,4 +1,4 @@
-# !/bin/bash
+#!/usr/bin/env bash
 #
 # Shell script which uploads completed swaptube output folders recursively
 # to a gcloud bucket using `gcloud storage cp` command.


### PR DESCRIPTION
this pr adds a flake.nix which can allow running
`nix develop` for cuda or
`nix develop .#hip` for hip when in the root of the repo.

----
only tested on hip as i have an amdgpu but cuda _should_ work