### PR TITLE
Fix various crashes

### DIFF
--- a/src/CUDA/Beavers/beaver_grid.cu
+++ b/src/CUDA/Beavers/beaver_grid.cu
@@ -37,7 +37,7 @@ __device__ void decode_turing_machine_index(int x, int y, int grid_w, int grid_h
     }
 }
 
-__global__ void beaver_grid_kernel(int num_states, int num_symbols, uint32_t* pixels, const Cuda::ivec2& wh, int grid_w, int grid_h, Cuda::vec2 lx_ty, Cuda::vec2 rx_by, int max_steps) {
+__global__ void beaver_grid_kernel(int num_states, int num_symbols, uint32_t* pixels, const Cuda::ivec2 wh, int grid_w, int grid_h, Cuda::vec2 lx_ty, Cuda::vec2 rx_by, int max_steps) {
     int idx = blockIdx.x * blockDim.x + threadIdx.x;
     int idy = blockIdx.y * blockDim.y + threadIdx.y;
 

--- a/src/CUDA/conway.cu
+++ b/src/CUDA/conway.cu
@@ -599,7 +599,7 @@ extern "C" void draw_conway(Bitboard* d_board, Bitboard* d_board_2, const Cuda::
     cudaDeviceSynchronize();
 }
 
-__global__ void initialize_boards(Bitboard* d_board, const Cuda::ivec2 grid_wh_bitboards, const uint32_t* d_envelope, const Cuda::ivec2& envelope_wh) {
+__global__ void initialize_boards(Bitboard* d_board, const Cuda::ivec2 grid_wh_bitboards, const uint32_t* d_envelope, const Cuda::ivec2 envelope_wh) {
     Cuda::ivec2 idx(blockDim.x * blockIdx.x + threadIdx.x, blockDim.y * blockIdx.y + threadIdx.y);
 
     Cuda::ivec2 envelope_pos = idx * envelope_wh / grid_wh_bitboards;

--- a/src/IO/SVG.cpp
+++ b/src/IO/SVG.cpp
@@ -107,11 +107,12 @@ Pixels svg_to_pix(const string& filename_with_or_without_suffix, ScalingParams& 
 
     // Render SVG
     if (!rsvg_handle_render_document(handle, cr, &viewport, &error)) {
+        auto e = runtime_error("Failed to render SVG file " + filename + ": " + error->message);
         g_error_free(error);
         cairo_destroy(cr);
         cairo_surface_destroy(surface);
         g_object_unref(handle);
-        throw runtime_error("Failed to render SVG file " + filename + ": " + error->message);
+        throw e;
     }
 
     // Copy pixels into Pixels object

--- a/src/Scenes/Common/TwoswapScene.cpp
+++ b/src/Scenes/Common/TwoswapScene.cpp
@@ -9,6 +9,8 @@ extern "C" void cuda_overlay(
     uint32_t* background, const ivec2& b_wh,
     const uint32_t* foreground, const ivec2& f_wh,
     const vec2& center, const float opacity, const float angle);
+extern "C" uint32_t* cuda_alloc_pixels_on_device(int size);
+extern "C" void cuda_copy_pixels_to_device(uint32_t* h_pixels, int size, uint32_t* d_pixels);
 
 TwoswapScene::TwoswapScene(const vec2& dimensions) : MandelbrotScene(dimensions) {
     manager.set({
@@ -53,54 +55,78 @@ void TwoswapScene::draw(){
     const ivec2 wh = get_width_height();
 
     if (twoswapness > 0.01) { // 2swap logo effect
-        Pixels foreground_pix(floor(wh * vec2(1, .3)));
+        if (!twoswap) {
+            twoswap_wh = floor(wh * vec2(1, .3));
 
-        ScalingParams sp(wh * vec2(.6, .4));
-        Pixels twoswap_pix = latex_to_pix("\\text{2swap}", sp);
-        foreground_pix.fill_circle(ivec2(get_width()/3, foreground_pix.wh.y/2), get_width()/23, OPAQUE_WHITE);
-        double yval = (foreground_pix.wh.y-twoswap_pix.wh.y)/2+get_width()/96;
-        foreground_pix.overwrite(twoswap_pix, ivec2(get_width()/3+get_width()/23+get_width()/96, yval));
+            Pixels foreground_pix(twoswap_wh);
+
+            ScalingParams sp(wh * vec2(.6, .4));
+            Pixels twoswap_pix = latex_to_pix("\\text{2swap}", sp);
+            foreground_pix.fill_circle(ivec2(get_width()/3, foreground_pix.wh.y/2), get_width()/23, OPAQUE_WHITE);
+            double yval = (foreground_pix.wh.y-twoswap_pix.wh.y)/2+get_width()/96;
+            foreground_pix.overwrite(twoswap_pix, ivec2(get_width()/3+get_width()/23+get_width()/96, yval));
+
+            int foreground_size = foreground_pix.wh.x * foreground_pix.wh.y;
+            twoswap = cuda_alloc_pixels_on_device(foreground_size);
+            cuda_copy_pixels_to_device(foreground_pix.pixels.data(), foreground_size, twoswap);
+        }
 
         cuda_overlay(gpu_pix->get_ptr(), wh,
-            foreground_pix.pixels.data(), foreground_pix.wh,
-            (wh-foreground_pix.wh)/2 - wh*.04 + whole_shift,
+            twoswap, twoswap_wh,
+            (wh-twoswap_wh)/2 - wh*.04 + whole_shift,
             twoswapness * .6, -.2
         );
     }
 
     if (seefness > 0.01) { // 6884 logo effect
-        Pixels foreground_pix(floor(get_width() * vec2(1, .2)));
+        if (!seef) {
+            seef_wh = floor(get_width() * vec2(1, .2));
 
-        Pixels image;
-        png_to_pix(image, "../musicnote");
+            Pixels foreground_pix(seef_wh);
 
-        Pixels scaled;
-        image.scale_to_bounding_box(wh * vec2(1, .135), scaled);
+            Pixels image;
+            png_to_pix(image, "../musicnote");
 
-        foreground_pix.overlay_cpu(scaled, vec2(get_width()*.44, (foreground_pix.wh.y)/2 + scaled.wh.y*.05), 1.0f);
+            Pixels scaled;
+            image.scale_to_bounding_box(wh * vec2(1, .135), scaled);
 
-        ScalingParams sp(wh * .25);
-        Pixels seef_pix = latex_to_pix("\\text{6884}", sp);
-        double yval = (foreground_pix.wh.y-seef_pix.wh.y)/2;
-        foreground_pix.overwrite(seef_pix, ivec2(get_width()*.4 + scaled.wh.x+get_width()/96, yval));
+            foreground_pix.overlay_cpu(scaled, vec2(get_width()*.44, (foreground_pix.wh.y)/2 + scaled.wh.y*.05), 1.0f);
+
+            ScalingParams sp(wh * .25);
+            Pixels seef_pix = latex_to_pix("\\text{6884}", sp);
+            double yval = (foreground_pix.wh.y-seef_pix.wh.y)/2;
+            foreground_pix.overwrite(seef_pix, ivec2(get_width()*.4 + scaled.wh.x+get_width()/96, yval));
+
+            int foreground_size = foreground_pix.wh.x * foreground_pix.wh.y;
+            seef = cuda_alloc_pixels_on_device(foreground_size);
+            cuda_copy_pixels_to_device(foreground_pix.pixels.data(), foreground_size, seef);
+        }
 
         cuda_overlay(gpu_pix->get_ptr(), wh,
-            foreground_pix.pixels.data(), foreground_pix.wh,
-            (get_width()-foreground_pix.wh)/2 - wh*vec2(.029, .285) + whole_shift,
+            seef, seef_wh,
+            (get_width()-seef_wh)/2 - wh*vec2(.029, .285) + whole_shift,
             seefness * .6, -.2
         );
     }
 
     if (swaptubeness > 0.01) { // SwapTube logo effect
-        vec2 size = wh * vec2(1, .14);
-        ScalingParams sp2(wh * vec2(.32, .14));
-        Pixels swaptube_pix_small_box = latex_to_pix("\\normalsize\\textbf{Made with love, using SwapTube}\\\\\\\\\\ \\text{\\quad Commit Hash: " + swaptube_commit_hash() + "}", sp2);
-        Pixels swaptube_pix = Pixels(wh);
-        swaptube_pix.overwrite(swaptube_pix_small_box, (size - swaptube_pix_small_box.wh)/2);
+        if (!swaptube) {
+            swaptube_wh = wh;
+
+            vec2 size = wh * vec2(1, .14);
+            ScalingParams sp2(wh * vec2(.32, .14));
+            Pixels swaptube_pix_small_box = latex_to_pix("\\normalsize\\textbf{Made with love, using SwapTube}\\\\\\\\\\ \\text{\\quad Commit Hash: " + swaptube_commit_hash() + "}", sp2);
+            Pixels swaptube_pix = Pixels(wh);
+            swaptube_pix.overwrite(swaptube_pix_small_box, (size - swaptube_pix_small_box.wh)/2);
+
+            int foreground_size = swaptube_pix.wh.x * swaptube_pix.wh.y;
+            swaptube = cuda_alloc_pixels_on_device(foreground_size);
+            cuda_copy_pixels_to_device(swaptube_pix.pixels.data(), foreground_size, swaptube);
+        }
 
         cuda_overlay(gpu_pix->get_ptr(), wh,
-            swaptube_pix.pixels.data(), swaptube_pix.wh,
-            (wh-swaptube_pix.wh)/2 + get_width_height()*vec2(.08, .28) + whole_shift,
+            swaptube, swaptube_wh,
+            (wh-swaptube_wh)/2 + get_width_height()*vec2(.08, .28) + whole_shift,
             swaptubeness * .6, -.2
         );
     }

--- a/src/Scenes/Common/TwoswapScene.h
+++ b/src/Scenes/Common/TwoswapScene.h
@@ -11,6 +11,12 @@
 void stripey_effect(Pixels& in, Pixels& out, const float amount);
 
 class TwoswapScene : public MandelbrotScene {
+    uint32_t* twoswap = nullptr;
+    uint32_t* seef = nullptr;
+    uint32_t* swaptube = nullptr;
+
+    ivec2 twoswap_wh, seef_wh, swaptube_wh;
+
 public:
     TwoswapScene(const vec2& dimensions = vec2(1, 1));
 


### PR DESCRIPTION
- Fix reference to host memory in `beaver_grid_kernel()` argument
- Fix reference to host memory in `initialize_boards()` argument
- Fix use of overlay pixels allocated in host memory in `TwoswapScene::draw()`, precompose all overlays on first use for reuse later
- Fix potential crash in `svg_to_pix()` from premature free of `GError` object returned by `rsvg_handle_render_document()` before exception is thrown